### PR TITLE
Add Mariadb container and data loading scripts

### DIFF
--- a/db/.env
+++ b/db/.env
@@ -1,0 +1,1 @@
+MYSQL_ROOT_PASSWORD=changeme

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,17 @@
+# Database
+
+Tokenized data is stored in a Mariadb database. To run Mariadb locally:
+
+## Setup
+
+Although we're running Mariadb in a Docker container, you'll probably want the MySQL command line utilities. If you don't already have these, you can install them with `brew install mysql` in OS X.
+
+To run the Docker container, run the following command optionally changing the password set in `.env`.
+
+```
+docker run --name mariadb -v conf:/etc/mysql/conf.d --env-file .env -p=3306:3306 -d mariadb:10.5.1
+```
+
+You may want to change the root password in `.env`.
+
+The data loading scripts are useful for loading the example data into the database and assume execution from this directory. The scripts also assume the existence of the files `source/ftf-all-filings.tsv` and `data/training.csv` in this repository.

--- a/db/README.md
+++ b/db/README.md
@@ -12,6 +12,20 @@ To run the Docker container, run the following command optionally changing the p
 docker run --name mariadb -v conf:/etc/mysql/conf.d --env-file .env -p=3306:3306 -d mariadb:10.5.1
 ```
 
-You may want to change the root password in `.env`.
-
 The data loading scripts are useful for loading the example data into the database and assume execution from this directory. The scripts also assume the existence of the files `source/ftf-all-filings.tsv` and `data/training.csv` in this repository.
+
+```
+mysql -uroot -p --protocol tcp < scripts/create_schema.sql
+mysql -uroot -p --protocol tcp deepform < scripts/load_document_data.sql
+mysql -uroot -p --protocol tcp deepform < scripts/load_token_data.sql
+```
+
+## Further notes
+
+When running a Mariadb database in Docker, you'll need to specify the protocol to use when interacting with the database like so:
+
+```
+mysql -uroot -p -e "SHOW CREATE DATABASE deepform;" --protocol tcp deepform
+```
+
+The `mysql` command defaults to using unix file sockets if no protocol is specified, and won't connect to the database.

--- a/db/conf/config-file.cnf
+++ b/db/conf/config-file.cnf
@@ -1,0 +1,1 @@
+bind-address=0.0.0.0

--- a/db/scripts/create_schema.sql
+++ b/db/scripts/create_schema.sql
@@ -1,0 +1,31 @@
+CREATE DATABASE `deepform`;
+
+CREATE TABLE `document` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `dc_slug` varchar(256) DEFAULT NULL,
+  `filing_type` varchar(256) DEFAULT NULL,
+  `contract_number` int(11) DEFAULT NULL,
+  `url` varchar(256) DEFAULT NULL,
+  `committee` varchar(256) DEFAULT NULL,
+  `agency` varchar(256) DEFAULT NULL,
+  `callsign` varchar(10) DEFAULT NULL,
+  `thumbnail_url` varchar(256) DEFAULT NULL,
+  `market_id` int(11) DEFAULT NULL,
+  `upload_date` datetime DEFAULT NULL,
+  `gross_amount_usd` double DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_dc_slug` (`dc_slug`)
+) ENGINE=InnoDB AUTO_INCREMENT=68175 DEFAULT CHARSET=latin1;
+
+CREATE TABLE `token` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `dc_slug` varchar(256) DEFAULT NULL,
+  `page` float DEFAULT NULL,
+  `x0` double DEFAULT NULL,
+  `y0` double DEFAULT NULL,
+  `x1` double DEFAULT NULL,
+  `y1` double DEFAULT NULL,
+  `token` varchar(256) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `origin_document` (`dc_slug`)
+) ENGINE=InnoDB AUTO_INCREMENT=14024491 DEFAULT CHARSET=latin1;

--- a/db/scripts/create_schema.sql
+++ b/db/scripts/create_schema.sql
@@ -1,5 +1,7 @@
 CREATE DATABASE `deepform`;
 
+USE `deepform`;
+
 CREATE TABLE `document` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `dc_slug` varchar(256) DEFAULT NULL,

--- a/db/scripts/load_document_data.sql
+++ b/db/scripts/load_document_data.sql
@@ -1,0 +1,5 @@
+LOAD DATA LOCAL INFILE '../source/ftf-all-filings.tsv'
+  INTO TABLE document
+  COLUMNS TERMINATED BY '\t'
+  IGNORE 1 LINES
+  (id, filing_type, contract_number, url, committee, agency, callsign, dc_slug, thumbnail_url, gross_amount_usd, market_id, upload_date);

--- a/db/scripts/load_token_data.sql
+++ b/db/scripts/load_token_data.sql
@@ -1,0 +1,9 @@
+ALTER TABLE token DISABLE KEYS;
+BEGIN;
+LOAD DATA LOCAL INFILE '../data/training.csv'
+  INTO TABLE token
+  COLUMNS TERMINATED BY ','
+  IGNORE 1 LINES
+  (dc_slug,page,x0,y0,x1,y1,token,@dummy);
+COMMIT;
+ALTER TABLE token ENABLE KEYS;


### PR DESCRIPTION
Adds instructions for running a [Mariadb](https://mariadb.org/about/) docker container and scripts for loading in the data.